### PR TITLE
ci: don't fail develop sync when branch is missing

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -40,7 +40,12 @@ jobs:
 
       - name: Fast-forward develop to main
         run: |
-          git fetch origin main develop
+          git fetch origin main
+          if ! git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
+            echo "::warning::No develop branch. If it was auto-deleted on merge, turn off 'Automatically delete head branches' in repo settings — develop is permanent. Skipping."
+            exit 0
+          fi
+          git fetch origin develop
           if git merge-base --is-ancestor origin/develop origin/main; then
             git push origin "origin/main:refs/heads/develop"
             echo "develop fast-forwarded to $(git rev-parse --short origin/main)."

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -122,7 +122,12 @@ jobs:
       - name: Fast-forward develop to main
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git fetch origin main develop
+          git fetch origin main
+          if ! git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
+            echo "::warning::No develop branch; skipping sync."
+            exit 0
+          fi
+          git fetch origin develop
           if git merge-base --is-ancestor origin/develop origin/main; then
             git push origin "origin/main:refs/heads/develop"
           else


### PR DESCRIPTION
If develop was auto-deleted on PR merge, the FF steps used to die on `git fetch develop` (exit 128). Check existence with git ls-remote first and warn-and-skip instead. The real fix is disabling "auto-delete head branches" so the permanent develop branch survives merges.