### PR TITLE
fix: drop unsupported cooldown key for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,9 +39,9 @@ updates:
       interval: 'monthly'
       time: '09:00'
       timezone: 'Europe/Paris'
+    # github-actions has no semver-* cooldown keys (tags aren't semver).
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       patch-and-minor:
         update-types:


### PR DESCRIPTION
semver-major-days isn't valid for the github-actions ecosystem (tags aren't semver), and the parse error made Dependabot ignore the entire config. Keep default-days only there; the npm block keeps its semver cooldowns.